### PR TITLE
Implement datetime64 as the time dtype

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,18 +28,19 @@ jobs:
         environment-file: environment.yml
         python-version: ${{ matrix.python-version }}
         auto-update-conda: true
-        auto-activate-base: false
+        auto-activate-base: true
         
     - name: Update and install packages
       run: |
         python -m pip install --upgrade pip wheel
         pip install nose
+        pip install pytest
         pip install coveralls
         pip install .
 
     - name: Run tests
       shell: bash -l {0}
-      run: |          
+      run: |
         nosetests -v --with-coverage --cover-package=dolfyn dolfyn
 
     - name: Upload coverage data to coveralls.io

--- a/README.md
+++ b/README.md
@@ -7,21 +7,21 @@
 BIG NEWS!!!
 ------
 
-Hello everyone! Just so that you know, dolfyn 0.13.0 has just been
-released (available on PyPi), and it is a MAJOR REFACTOR of the code
-so that DOLfYN is now built on xarray, rather than the hokey
-`pyDictH5` package that I'd built.
+Hello everyone! Just so that you know, we are preparing to release
+dolfyn 1.0! This is a MAJOR REFACTOR of the code so that DOLfYN is
+now built on xarray, rather than the somewhat contrived and
+purpose-built `pyDictH5` package.
 
-This means that DOLfYN 0.13.0 is _not_ backwards compatible with
+This means that DOLfYN 1.0 is _not_ backwards compatible with
 earlier version. This, in turn, means two things:
 
 1. The data files (`.h5` files) you created with earlier versions
-of DOLfYN will no longer load with DOLfYN 0.13.0.
-2. The syntax of DOLfYN 0.13.0 is completely different from earlier version.
+of DOLfYN will no longer load with DOLfYN 1.0.0.
+2. The syntax of DOLfYN 1.0 is completely different from earlier version.
 
 Because of this, it's probably easiest to continue using earlier
 versions of DOLfYN for your old data. If you want to bring some data
-into DOLfYN 0.13, you will need to
+into DOLfYN 1.0, you will need to
 `dolfyn.read(binary_source_file.VEC)`, and then refactor your code to
 work properly with DOLfYN's new syntax. I may be providing some
 updates to dolfyn 0.12 via the v0.12-backports branch (and associated
@@ -34,11 +34,11 @@ robust, powerful, and compatible tool -- especially because we now
 write/load xarray-formatted netcdf4 files, which is becoming a
 standard.
 
-Also, we are treating the 0.13 version as a beta-testing release
-before we probably move to 1.0! According to the [sematic versioning
-rules](https://semver.org) that we try to follow, this means that the
-code can be considered much more stable than it has been so far, and
-these kinds of unannounced compatability changes shouldn't happen.
+For the immediate future we will be doing pre-releases to DOLfYN 1.0
+using "release candidates", following the "1.0.0-rc#" naming
+convention. Many of these changes were also released under version
+0.13, but we are moving away from that version toward 1.0. If you are
+using 0.13, we recommend switching to 1.0 (pre-release for now).
 
 A **HUGE THANK YOU** to @jmcvey3 who did the vast majority of the work
 to make this happen.

--- a/changelog.md
+++ b/changelog.md
@@ -4,82 +4,88 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Version 0.13.1
+	- Change the xarray dataset-accessor from `Veldata` to `velds`.
+	- Begin reimplementing DOLfYN API in the velocity.Velocity class (accessed via velds above)
+	- Switch from epoch time to datetime64 in datasets
+	        - This also includes a bugfix where the epoch time was machine specific.
+
 ## Version 0.13.0
 	- Refactored source code to use xarray instead of h5py-derived data objects
-	
+
 	- Input/Output:
 		- I/O now returns xarray Datasets
 		- Variables names are now consistent across all instruments
 		- Rotation and orientation matrices are all saved as xarray variables
-		
+
 		- Created functions to handle saving/loading dolfyn datasets to/from netCDF and MATLAB file formats
 			- It is possible to open dolfyn datasets using `xarray.open_dataset()`, but not possible to save through` xarray.to_netcdf()`
-		
+
 		- Scaling bugs:
 			- Fixed AWAC temperature scaling
 			- Fixed scaling on all `ambig_vel` variables
 			- Fixed Signature magnetometer to return in units of microTeslas
 			- Fixed Nortek echosounder 'dB' scaling
-			
+
 		- Fixed error in Nortek 'range' calculation (bin 1 dist = blank dist + cell size)
 		- Added function in the ADCP API to add the deployment depth to this range (`clean.set_deploy_altitude()`)
-		
+
 		- Rounded Nortek AWAC blanking distance and range to 2 decimal places
-		- Read support for 2-4 beam 
+		- Read support for 2-4 beam
 
 		- Fix error reading VMDAS-processed files
 		- Switch from `'lonlat` to `latlon` as the designated entry-name in `dat.attrs`
-		
+
 		- Created function to handle nans in ADV orientation matrix data so that rotation code won't fail
 
 		- Removed user-nonsensical configuration data
 		- Changed true/false attributes to 1/0 - Logical values are auto-dropped when saving netCDF
-		
+
 	- Rotations:
 		- `rotate2()`, `set_inst2head_rotmat()`, `calc_principal_heading()`, and `set_declination()` now located in `rotate.api` and can be accessed using `dolfyn.<function>`
-		
+
 		- Solved errors where orientation wasn't taken into account for Nortek Signatures
 			- Fixed Nortek Signature rotation issues for fixed up vs down
 			- Fixed AHRS-equipped Nortek Signature rotation issues
 			- AHRS orientmat is the transpose of dolfyn's HPR-calculated orientation matrix
-			
+
 	- Motion correction code:
 		- `CorrectMotion` object has been removed
 		- replaced '.mean()' with `np.nanmean` in `motion_correction` and `calc_principal_heading`
-		
+
 	- `TimeData`, `Velocity`, `TKEdata`:
 		- `TimeData` class has been removed
 		- Combined `Velocity` and `TKEdata` classes into `Velocity`, which now contains all dolfyn shortcuts
 		- `Velocity` class is set up with xarray accessor `Veldata`
 		- All properties return `xarray.DataArrays`
 		- Added a property to calculate wavenumber `k` from the spectral frequency vector
-		
+
 	- TimeBinner, VelBinner, TurbBinner class refactoring:
 		- Changed `.mean()` to `np.nanmean()` so functions can handle nans
-		
+
 		- `TurbBinner` renamed to `ADVBinner` and set in the ADV API
-		
+
 		- Renamed `calc_vel_psd()` and `calc_vel_csd()` to `calc_psd` and `calc_csd`
 		- Fixed bug where `calc_vel_csd()` wasn't using "n_fft_coh" input
 		- Added "freq_units" option to `calc_psd()` and `calc_csd()` using either frequency in Hz (f) or rad/s (omega) ("freq_units" input)
 				- Renamed `calc_omega()` to `calc_freq()` and added "freq_units" as input
 				- Calling `TurbBinner`/`calc_turbulence()` still automatically use 'rad/s'
 		- FFT frequency "omega"|"f" is now a xarray coordinate rather than its own variable
-				
+
 		- "do" functions take Datasets as input, "calc" funtions take DataArrays as input
-		
+
 		- Updated `U_dir` description to be CCW from East (consistent with imag vs real axes)
 		- Added `convert_degrees()` function in tools.misc to convert CCW from East to CW from North, and vice versa
-		
+
 		- Renamed `sigma_Uh` variable to `U_std` and moved it from adv.turbulence to velocity.VelBinner as a function in `do_avg()`
 		- Renamed properties `Ecoh` to `E_coh` and `Itke` to `I_tke`
 		- Removed `Itke_thresh` from `TurbBinner` and added to `Velocity` class as it is only used with the `I_tke` property
-			
+
 		- Coherence, phase_angle, and auto-/cross-covariance now work as described in their docstrings
 			- Will take 1D or 3D velocity arrays as input
 			- Renamed `cohere()` and `phase_angle()` to `calc_coh()` and `calc_phase_angle()`
 			- Fixed bug where `tools.psd.coherence` wasn't correctly calling `tools.psd.cpsd` or `tools.psd.cpsd_quasisync`
-			
+
 		- Updated turbulence dissipation functions return correctly for xarray
 			- Fixed `calc_turbulence()` '__call__' error
 			- Removed inputs not used by `calc_turbulence()` and `ADVBinner` function call ('omega_range' and 'out_type')
@@ -95,13 +101,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 			- `clean_fill()` function takes this mask as input, removes bad data, and interpolates it
 		- Added `surface_from_P()` and `correlation_filter()` functions to ADP cleaning functions
 		- ADP `fillgaps_time()` and `fillgaps_depth()` and ADV `clean_fill()` use xarray's `na_interpolate()` to fill in bad data.
-		
+
 	- Time:
 		- Removed mpltime support and changed to epoch time (seconds since 1970/1/1 00:00:00)
 		- Solved bug where unaware timestamp would convert to different times depending on working computer timezone
 			- Instrument time remains in the timezone in which it was logged by the instrument, no matter the timezone of the user analyzing the data
 		- Added code to convert between epoch time <-> datetime <-> datestring, MATLAB datenum conversion functions
-		
+
 	- Testing updates:
 		- Added check signature velocity rotations against nortek matfiles
 		- Dropped testing for python 2.x because xarray doesn't support it

--- a/dolfyn/_version.py
+++ b/dolfyn/_version.py
@@ -1,4 +1,4 @@
-__version__ = '0.13.0'
+__version__ = '0.13.1'
 __prog_name__ = 'DOLfYN'
 __version_date__ = 'Aug-26-2021'
 

--- a/dolfyn/_version.py
+++ b/dolfyn/_version.py
@@ -1,14 +1,21 @@
-__version__ = '0.13.1'
+__version__ = '1.0.0-rc1'
 __prog_name__ = 'DOLfYN'
 __version_date__ = 'Aug-26-2021'
 
 
 def ver2tuple(ver):
     out = []
+    if '-' in __version__:
+        ver, pre_rel = ver.split('-')
+    else:
+        pre_rel = None
     for val in ver.split('.'):
         val = int(val)
         out.append(val)
-    return tuple(out)
+    if pre_rel is not None:
+        return tuple(out + [pre_rel])
+    else:
+        return tuple(out)
 
 
 version_info = ver2tuple(__version__)

--- a/dolfyn/adv/motion.py
+++ b/dolfyn/adv/motion.py
@@ -317,7 +317,7 @@ def correct_motion(ds,
         raise Exception('The instrument does not appear to have an IMU.')
 
     if ds.coord_sys != 'inst':
-        ds = rotate2(ds, 'inst', inplace=True)
+        ds = rotate2(ds, 'inst')
 
     # Returns True/False if head2inst_rotmat has been set/not-set.
     # Bad configs raises errors (this is to check for those)

--- a/dolfyn/binned.py
+++ b/dolfyn/binned.py
@@ -4,6 +4,7 @@ import warnings
 from .tools.psd import psd_freq, coherence, psd, cpsd_quasisync, cpsd, \
     phase_angle
 from .tools.misc import slice1d_along_axis, detrend
+from .time import epoch2dt64, dt642epoch
 warnings.simplefilter('ignore', RuntimeWarning)
 
 
@@ -156,6 +157,8 @@ class TimeBinner:
         n_bin : int (default is self.n_bin)
 
         """
+        if np.issubdtype(dat.dtype, np.datetime64):
+            return epoch2dt64(self._mean(dt642epoch(dat), axis=axis, n_bin=n_bin))
         if axis != -1:
             dat = np.swapaxes(dat, axis, -1)
         n_bin = self._parse_nbin(n_bin)

--- a/dolfyn/example_data/RDI_7f79.000
+++ b/dolfyn/example_data/RDI_7f79.000
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a037155da72fcde210dc0c93135edf75649b3d45ff18204f22f784c268cb84fd
+size 50000

--- a/dolfyn/io/api.py
+++ b/dolfyn/io/api.py
@@ -7,7 +7,7 @@ from .nortek2 import read_signature
 from .rdi import read_rdi
 from .base import _create_dataset
 from ..rotate.base import _set_coords
-from ..time import epoch2date, date2epoch, date2matlab, matlab2date
+from ..time import date2matlab, matlab2date, date2dt64, dt642date
 
 
 # time variables stored as data variables (as opposed to coordinates)
@@ -108,18 +108,6 @@ def save(dataset, filename):
             dataset = dataset.drop(var)
             dataset.attrs['complex_vars'].append(var)
 
-    # Keeping time in raw file's time instance, unaware of timezone
-    t_list = [t for t in dataset.coords if 'time' in t]
-    for ky in t_list:
-        dt = epoch2date(dataset[ky])
-        dataset = dataset.assign_coords({ky: dt})
-
-    t_data = [t for t in dataset.data_vars if t in t_additional]
-    for ky in t_data:
-        dt = epoch2date(dataset[ky])
-        dataset = dataset.drop_vars(ky)  # must do b/c of netcdf encoding error
-        dataset[ky] = xr.DataArray(dt, coords={'time_gps': dataset.time_gps})
-
     dataset.to_netcdf(filename, format='NETCDF4', engine='netcdf4')
 
 
@@ -161,20 +149,6 @@ def load(filename):
             ds = ds.drop_vars([var+'_real', var+'_imag'])
     ds.attrs.pop('complex_vars')
 
-    # Reload raw file's time instance since the timezone is unknown
-    t_list = [t for t in ds.coords if 'time' in t]
-    for ky in t_list:
-        dt = ds[ky].values.astype('datetime64[us]').tolist()
-        ds = ds.assign_coords({ky: date2epoch(dt)})
-        ds[ky].attrs['description'] = 'seconds since 1970-01-01 00:00:00'
-
-    # Time data variables
-    t_data = [t for t in ds.data_vars if t in t_additional]
-    for ky in t_data:
-        dt = ds[ky].values.astype('datetime64[us]').tolist()
-        ds[ky].data = date2epoch(dt)
-        ds[ky].attrs['description'] = 'seconds since 1970-01-01 00:00:00'
-
     return ds
 
 
@@ -210,12 +184,12 @@ def save_mat(dataset, filename, datenum=True):
     if datenum:
         t_list = [t for t in dataset.coords if 'time' in t]
         for ky in t_list:
-            dt = date2matlab(epoch2date(dataset[ky]))
+            dt = date2matlab(dt642date(dataset[ky]))
             dataset = dataset.assign_coords({ky: dt})
 
         t_data = [t for t in dataset.data_vars if t in t_additional]
         for ky in t_data:
-            dt = date2matlab(epoch2date(dataset[ky]))
+            dt = date2matlab(dt642date(dataset[ky]))
             dataset[ky].data = dt
 
     # Save xarray structure with more descriptive structure names
@@ -281,13 +255,13 @@ def load_mat(filename, datenum=True):
     if datenum:
         t_list = [t for t in ds.coords if 'time' in t]
         for ky in t_list:
-            dt = date2epoch(matlab2date(ds[ky].values))
+            dt = date2dt64(matlab2date(ds[ky].values))
             ds = ds.assign_coords({ky: dt})
             ds[ky].attrs['description'] = 'seconds since 1970-01-01 00:00:00'
 
         t_data = [t for t in ds.data_vars if t in t_additional]
         for ky in t_data:
-            dt = date2epoch(matlab2date(ds[ky].values))
+            dt = date2dt64(matlab2date(ds[ky].values))
             ds[ky].data = dt
             ds[ky].attrs['description'] = 'seconds since 1970-01-01 00:00:00'
 

--- a/dolfyn/io/nortek.py
+++ b/dolfyn/io/nortek.py
@@ -74,6 +74,8 @@ def read_nortek(filename, userdata=True, debug=False, do_checksum=False,
     if declin is not None:
         ds = rot.set_declination(ds, declin)
 
+    ds['time'] = time.epoch2dt64(ds['time']).astype('datetime64[us]')
+
     return ds
 
 
@@ -523,12 +525,12 @@ class _NortekReader():
         """Read the time from the first 6bytes of the input string.
         """
         min, sec, day, hour, year, month = unpack('BBBBBB', strng[:6])
-        return datetime(time._fullyear(_bcd2char(year)),
-                        _bcd2char(month),
-                        _bcd2char(day),
-                        _bcd2char(hour),
-                        _bcd2char(min),
-                        _bcd2char(sec)).timestamp()
+        return time.date2epoch(datetime(time._fullyear(_bcd2char(year)),
+                                        _bcd2char(month),
+                                        _bcd2char(day),
+                                        _bcd2char(hour),
+                                        _bcd2char(min),
+                                        _bcd2char(sec)))[0]
 
     def _init_data(self, vardict):
         """Initialize the data object according to vardict.

--- a/dolfyn/io/nortek2.py
+++ b/dolfyn/io/nortek2.py
@@ -8,6 +8,7 @@ from .base import _find_userdata, _create_dataset
 from ..rotate.vector import _euler2orient
 from ..rotate.base import _set_coords
 from ..rotate.api import set_declination
+from ..time import epoch2dt64
 
 
 def read_signature(filename, userdata=True, nens=None):
@@ -68,6 +69,12 @@ def read_signature(filename, userdata=True, nens=None):
                                        dims=['earth', 'inst', 'time'])
     if declin is not None:
         ds = set_declination(ds, declin)
+
+    # Convert time to dt64
+    t_list = [t for t in ds.coords if 'time' in t]
+    for ky in t_list:
+        dt = epoch2dt64(ds[ky]).astype('datetime64[us]')
+        ds = ds.assign_coords({ky: dt})
 
     return ds
 

--- a/dolfyn/io/nortek2_lib.py
+++ b/dolfyn/io/nortek2_lib.py
@@ -2,8 +2,7 @@ import struct
 import os.path as path
 import numpy as np
 #import warnings
-from datetime import datetime
-
+from .. import time
 
 def _reduce_by_average(data, ky0, ky1):
     # Average two arrays together, if they both exist.
@@ -82,7 +81,7 @@ def _calc_time(year, month, day, hour, minute, second, usec, zero_is_bad=True):
             continue
         try:
             # Note that month is zero-based, seconds since Jan 1 1970
-            dt[idx] = datetime(y, mo + 1, d, h, mi, s, u).timestamp()
+            dt[idx] = time.date2epoch(time.datetime(y, mo + 1, d, h, mi, s, u))[0]
         except ValueError:
             # One of the time values is out-of-range (e.g., mi > 60)
             # This probably indicates a corrupted byte, so we just insert None.

--- a/dolfyn/io/rdi.py
+++ b/dolfyn/io/rdi.py
@@ -1,6 +1,6 @@
 import numpy as np
 import xarray as xr
-import datetime
+from .. import time as tmlib
 import warnings
 from os.path import getsize
 from ._read_bin import bin_reader
@@ -8,6 +8,10 @@ from .base import _find_userdata, _create_dataset
 from ..rotate.rdi import _calc_beam_orientmat, _calc_orientmat
 from ..rotate.base import _set_coords
 from ..rotate.api import set_declination
+
+
+# time variables stored as data variables (as opposed to coordinates)
+t_additional = ['hdwtime_gps', ]
 
 
 def read_rdi(fname, userdata=None, nens=None, debug=0):
@@ -71,13 +75,25 @@ def read_rdi(fname, userdata=None, nens=None, debug=0):
     else:  # (not ENR or ENS) or WinRiver files
         ds.attrs['vel_gps_corrected'] = 0
 
+    # Convert time to dt64
+    t_list = [t for t in ds.coords if 'time' in t]
+    for ky in t_list:
+        dt = tmlib.epoch2dt64(ds[ky])
+        ds = ds.assign_coords({ky: dt})
+
+    t_data = [t for t in ds.data_vars if t in t_additional]
+    for ky in t_data:
+        dt = tmlib.epoch2dt64(ds[ky])
+        ds = ds.drop_vars(ky)  # must do b/c of netcdf encoding error
+        ds[ky] = xr.DataArray(dt, coords={'time_gps': ds.time_gps})
+        
     return ds
 
 
 def _remove_gps_duplicates(dat):
     """
     Removes duplicate and nan timestamp values in 'time_gps' coordinate, and    
-    adds hardware (ADCP DAQ) timestamp corresponding to GPS acquisition
+    ads hardware (ADCP DAQ) timestamp corresponding to GPS acquisition
     (in addition to the GPS unit's timestamp).
     """
 
@@ -375,8 +391,9 @@ class _RdiReader():
             for nm in self.vars_read:
                 _get(dat, nm)[..., iens] = self.mean(self.ensemble[nm])
             try:
-                dats = datetime.datetime(*clock[:6, 0],
-                                         microsecond=clock[6, 0] * 10000).timestamp()
+                dats = tmlib.date2epoch(
+                    tmlib.datetime(*clock[:6, 0],
+                                  microsecond=clock[6, 0] * 10000))[0]
             except ValueError:
                 warnings.warn("Invalid time stamp in ping {}.".format(
                     int(self.ensemble.number[0])))
@@ -798,24 +815,24 @@ class _RdiReader():
                            'flags',
                            'ntime', ]
         utim = fd.read_ui8(4)
-        date = datetime.datetime(utim[2] + utim[3] * 256, utim[1], utim[0])
+        date = tmlib.datetime(utim[2] + utim[3] * 256, utim[1], utim[0])
         # This byte is in hundredths of seconds (10s of milliseconds):
-        time = datetime.timedelta(milliseconds=(int(fd.read_ui32(1) / 10)))
+        time = tmlib.timedelta(milliseconds=(int(fd.read_ui32(1) / 10)))
         fd.seek(4, 1)  # "PC clock offset from UTC" - clock drift in ms?
-        ens.time_gps[k] = (date + time).timestamp()
+        ens.time_gps[k] = tmlib.date2epoch(date + time)[0]
         ens.latitude_gps[k] = fd.read_i32(1) * self._cfac
         ens.longitude_gps[k] = fd.read_i32(1) * self._cfac
-        ens.etime_gps[k] = (date + datetime.timedelta(
-            milliseconds=int(fd.read_ui32(1) * 10))).timestamp()
+        ens.etime_gps[k] = tmlib.date2epoch(date + tmlib.timedelta(
+            milliseconds=int(fd.read_ui32(1) * 10)))[0]
         ens.elatitude_gps[k] = fd.read_i32(1) * self._cfac
         ens.elongitude_gps[k] = fd.read_i32(1) * self._cfac
         fd.seek(12, 1)
         ens.flags[k] = fd.read_ui16(1)
         fd.seek(6, 1)
         utim = fd.read_ui8(4)
-        date = datetime.datetime(utim[0] + utim[1] * 256, utim[3], utim[2])
-        ens.ntime[k] = (date + datetime.timedelta(
-            milliseconds=int(fd.read_ui32(1) / 10))).timestamp()
+        date = tmlib.datetime(utim[0] + utim[1] * 256, utim[3], utim[2])
+        ens.ntime[k] = tmlib.date2epoch(date + tmlib.timedelta(
+            milliseconds=int(fd.read_ui32(1) / 10)))[0]
         fd.seek(16, 1)
         self._nbyte = 2 + 76
 
@@ -842,15 +859,15 @@ class _RdiReader():
                                   ' skipping...')
                 return 'FAIL'
             gga_time = str(self.f.reads(9))
-            time = datetime.timedelta(hours=int(gga_time[0:2]),
-                                      minutes=int(gga_time[2:4]),
-                                      seconds=int(gga_time[4:6]),
-                                      milliseconds=int(gga_time[7:])*100)
+            time = tmlib.timedelta(hours=int(gga_time[0:2]),
+                                  minutes=int(gga_time[2:4]),
+                                  seconds=int(gga_time[4:6]),
+                                  milliseconds=int(gga_time[7:])*100)
             clock = self.ensemble.rtc[:, :]
             if clock[0, 0] < 100:
                 clock[0, :] += century
-            ens.time_gps[k] = (datetime.datetime(
-                *clock[:3, 0]) + time).timestamp()
+            ens.time_gps[k] = tmlib.date2epoch(tmlib.datetime(
+                *clock[:3, 0]) + time)[0]
             self.f.seek(1, 1)
             ens.latitude_gps[k] = self.f.read_f64(1)
             tcNS = self.f.reads(1)

--- a/dolfyn/io/rdi.py
+++ b/dolfyn/io/rdi.py
@@ -486,14 +486,14 @@ class _RdiReader():
                 if cfgid[0] == 127 and cfgid[1] in [127, 121]:
                     if cfgid[1] == 121 and self._debug7f79 is None:
                         self._debug7f79 = True
-                        warnings.warn(
-                            "This ADCP file has an undocumented "
-                            "sync-code.  If possible, please notify the "
-                            "DOLfYN developers that you are recieving "
-                            "this warning by posting the hardware and "
-                            "software details on how you acquired this file "
-                            "to "
-                            "http://github.com/lkilcher/dolfyn/issues/7")
+                        # warnings.warn(
+                        #     "This ADCP file has an undocumented "
+                        #     "sync-code.  If possible, please notify the "
+                        #     "DOLfYN developers that you are recieving "
+                        #     "this warning by posting the hardware and "
+                        #     "software details on how you acquired this file "
+                        #     "to "
+                        #     "http://github.com/lkilcher/dolfyn/issues/7")
                     valid = 1
         else:
             fd.seek(-2, 1)

--- a/dolfyn/rotate/api.py
+++ b/dolfyn/rotate/api.py
@@ -22,7 +22,7 @@ rot_module_dict = {
     'rdi': r_rdi}
 
 
-def rotate2(ds, out_frame='earth', inplace=False):
+def rotate2(ds, out_frame='earth'):
     """Rotate a dataset to a new coordinate system.
 
     Parameters
@@ -31,9 +31,6 @@ def rotate2(ds, out_frame='earth', inplace=False):
       The dolfyn dataset (ADV or ADCP) to rotate.
     out_frame : string {'beam', 'inst', 'earth', 'principal'}
       The coordinate system to rotate the data into.
-    inplace : bool
-      Operate on the input data dataset (True), or return a copy that
-      has been rotated (False, default).
 
     Returns
     -------
@@ -67,8 +64,8 @@ def rotate2(ds, out_frame='earth', inplace=False):
     if rmod is None:
         raise ValueError("Rotations are not defined for "
                          "instrument '{}'.".format(_make_model(ds)))
-    if not inplace:
-        ds = ds.copy(deep=True)
+    # Ensure new data is rotated
+    ds = ds.copy(deep=True)
 
     # Get the 'indices' of the rotation chain
     try:
@@ -209,7 +206,7 @@ def set_declination(ds, declin):
 
     if ds.coord_sys == 'earth':
         rotate2earth = True
-        ds = rotate2(ds, 'inst', inplace=True)
+        ds = rotate2(ds, 'inst')
     else:
         rotate2earth = False
 
@@ -219,7 +216,7 @@ def set_declination(ds, declin):
     if 'heading' in ds:
         ds['heading'] += angle
     if rotate2earth:
-        ds = rotate2(ds, 'earth', inplace=True)
+        ds = rotate2(ds, 'earth')
     if 'principal_heading' in ds.attrs:
         ds.attrs['principal_heading'] += angle
 
@@ -255,7 +252,7 @@ def set_inst2head_rotmat(ds, rotmat):
 
     csin = ds.coord_sys
     if csin not in ['inst', 'beam']:
-        ds = rotate2(ds, 'inst', inplace=True)
+        ds = rotate2(ds, 'inst')
 
     ds['inst2head_rotmat'] = xr.DataArray(np.array(rotmat),
                                           dims=['x', 'x*'])
@@ -268,6 +265,6 @@ def set_inst2head_rotmat(ds, rotmat):
     if not csin == 'beam':  # csin not 'beam', then we're in inst
         ds = r_vec._rotate_inst2head(ds)
     if csin not in ['inst', 'beam']:
-        ds = rotate2(ds, csin, inplace=True)
+        ds = rotate2(ds, csin)
 
     return ds

--- a/dolfyn/tests/base.py
+++ b/dolfyn/tests/base.py
@@ -1,8 +1,24 @@
 import pkg_resources
 import atexit
 import dolfyn.io.api as io
+import numpy as np
+from .. import time
+from xarray.testing import assert_allclose as _assert_allclose
 
 atexit.register(pkg_resources.cleanup_resources)
+
+
+def assert_allclose(dat0, dat1, *args, **kwargs):
+    names = []
+    for v in dat0.variables:
+        if np.issubdtype(dat0[v].dtype, np.datetime64):
+            dat0[v] = time.dt642epoch(dat0[v])
+            dat1[v] = time.dt642epoch(dat1[v])
+            names.append(v)
+    _assert_allclose(dat0, dat1, *args, **kwargs)
+    for v in names:
+        dat0[v] = time.epoch2dt64(dat0[v])
+        dat1[v] = time.epoch2dt64(dat1[v])
 
 
 def drop_config(dataset):

--- a/dolfyn/tests/data/RDI_7f79.nc
+++ b/dolfyn/tests/data/RDI_7f79.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d850c91d3873bc28e6b5dd6c589ebdb2d87c2af053a0647c945eb3039c4b8b1b
+size 81483

--- a/dolfyn/tests/test_analysis.py
+++ b/dolfyn/tests/test_analysis.py
@@ -1,6 +1,7 @@
 from dolfyn.tests import test_read_adp as tr, test_read_adv as tv
 from dolfyn.tests.base import load_ncdata as load, save_ncdata as save
-from xarray.testing import assert_allclose, assert_identical
+from xarray.testing import assert_identical
+from .base import assert_allclose
 import numpy as np
 from dolfyn import VelBinner, read_example
 import dolfyn.adv.api as avm

--- a/dolfyn/tests/test_motion.py
+++ b/dolfyn/tests/test_motion.py
@@ -31,7 +31,7 @@ def test_motion_adv(make_data=False):
     # test motion-corrected data rotation
     tdmE = tv.dat_imu.copy(deep=True)
     tdmE = set_declination(tdmE, 10.0)
-    tdmE = rotate2(tdmE, 'earth', inplace=True)
+    tdmE = rotate2(tdmE, 'earth')
     tdmE = avm.correct_motion(tdmE)
 
     if make_data:

--- a/dolfyn/tests/test_read_adp.py
+++ b/dolfyn/tests/test_read_adp.py
@@ -14,6 +14,7 @@ load = tb.load_ncdata
 save = tb.save_ncdata
 
 dat_rdi = load('RDI_test01.nc')
+dat_rdi_7f79 = load('RDI_7f79.nc')
 dat_rdi_bt = load('RDI_withBT.nc')
 dat_rdi_vm = load('vmdas01.nc')
 dat_wr1 = load('winriver01.nc')
@@ -43,6 +44,7 @@ def test_io_rdi(make_data=False):
     warnings.simplefilter('ignore', UserWarning)
     nens = 500
     td_rdi = tb.drop_config(read('RDI_test01.000'))
+    td_7f79 = tb.drop_config(read('RDI_7f79.000'))
     td_rdi_bt = tb.drop_config(read('RDI_withBT.000', nens=nens))
     td_vm = tb.drop_config(read('vmdas01.ENX', nens=nens))
     td_wr1 = tb.drop_config(read('winriver01.PD0'))
@@ -52,6 +54,7 @@ def test_io_rdi(make_data=False):
 
     if make_data:
         save(td_rdi, 'RDI_test01.nc')
+        save(td_7f79, 'RDI_7f79.nc')
         save(td_rdi_bt, 'RDI_withBT.nc')
         save(td_vm, 'vmdas01.nc')
         save(td_wr1, 'winriver01.nc')
@@ -59,6 +62,7 @@ def test_io_rdi(make_data=False):
         return
 
     assert_allclose(td_rdi, dat_rdi, atol=1e-6)
+    assert_allclose(td_7f79, dat_rdi_7f79, atol=1e-6)
     assert_allclose(td_rdi_bt, dat_rdi_bt, atol=1e-6)
     assert_allclose(td_vm, dat_rdi_vm, atol=1e-6)
     assert_allclose(td_wr1, dat_wr1, atol=1e-6)

--- a/dolfyn/tests/test_read_adp.py
+++ b/dolfyn/tests/test_read_adp.py
@@ -7,7 +7,7 @@ import warnings
 import os
 import sys
 import unittest
-from xarray.testing import assert_allclose
+from .base import assert_allclose
 import pytest
 
 load = tb.load_ncdata

--- a/dolfyn/tests/test_read_adv.py
+++ b/dolfyn/tests/test_read_adv.py
@@ -5,10 +5,11 @@ from dolfyn.rotate.api import set_inst2head_rotmat
 import dolfyn.io.nortek as vector
 from dolfyn.io.api import read_example as read
 import dolfyn.tests.base as tb
-from xarray.testing import assert_allclose
+
 
 load = tb.load_ncdata
 save = tb.save_ncdata
+assert_allclose = tb.assert_allclose
 
 dat = load('vector_data01.nc')
 dat_imu = load('vector_data_imu01.nc')

--- a/dolfyn/tests/test_rotate_adp.py
+++ b/dolfyn/tests/test_rotate_adp.py
@@ -2,7 +2,7 @@ from dolfyn.tests import test_read_adp as tr
 from dolfyn.tests.base import load_ncdata as load, save_ncdata as save
 from dolfyn.rotate.api import rotate2, calc_principal_heading
 import numpy as np
-from xarray.testing import assert_allclose
+from .base import assert_allclose
 import numpy.testing as npt
 
 

--- a/dolfyn/tests/test_rotate_adp.py
+++ b/dolfyn/tests/test_rotate_adp.py
@@ -34,13 +34,13 @@ def test_rotate_beam2inst(make_data=False):
 def test_rotate_inst2beam(make_data=False):
 
     td = load('RDI_test01_rotate_beam2inst.nc')
-    td = rotate2(td, 'beam', inplace=True)
+    td = rotate2(td, 'beam')
     td_awac = load('AWAC_test01_earth2inst.nc')
-    td_awac = rotate2(td_awac, 'beam', inplace=True)
+    td_awac = rotate2(td_awac, 'beam')
     td_sig = load('BenchFile01_rotate_beam2inst.nc')
-    td_sig = rotate2(td_sig, 'beam', inplace=True)
+    td_sig = rotate2(td_sig, 'beam')
     td_sig_i = load('Sig1000_IMU_rotate_beam2inst.nc')
-    td_sig_i = rotate2(td_sig_i, 'beam', inplace=True)
+    td_sig_i = rotate2(td_sig_i, 'beam')
     td_sig_ie = load('Sig500_Echo_earth2inst.nc')
     td_sig_ie = rotate2(td_sig_ie, 'beam')
 
@@ -77,9 +77,9 @@ def test_rotate_inst2earth(make_data=False):
     td = rotate2(tr.dat_rdi, 'earth')
     tdwr2 = rotate2(tr.dat_wr2, 'earth')
     td_sig = load('BenchFile01_rotate_beam2inst.nc')
-    td_sig = rotate2(td_sig, 'earth', inplace=True)
+    td_sig = rotate2(td_sig, 'earth')
     td_sig_i = load('Sig1000_IMU_rotate_beam2inst.nc')
-    td_sig_i = rotate2(td_sig_i, 'earth', inplace=True)
+    td_sig_i = rotate2(td_sig_i, 'earth')
 
     if make_data:
         save(td_awac, 'AWAC_test01_earth2inst.nc')
@@ -90,7 +90,7 @@ def test_rotate_inst2earth(make_data=False):
         save(td_sig_ie, 'Sig500_Echo_earth2inst.nc')
 
         return
-    td_awac = rotate2(td_awac, 'earth', inplace=True)
+    td_awac = rotate2(td_awac, 'earth')
     td_sig_ie = rotate2(td_sig_ie, 'earth')
     td_sig_o = rotate2(td_sig_o.drop_vars('orientmat'), 'earth')
 
@@ -112,16 +112,16 @@ def test_rotate_inst2earth(make_data=False):
 def test_rotate_earth2inst():
 
     td_rdi = load('RDI_test01_rotate_inst2earth.nc')
-    td_rdi = rotate2(td_rdi, 'inst', inplace=True)
+    td_rdi = rotate2(td_rdi, 'inst')
     tdwr2 = load('winriver02_rotate_ship2earth.nc')
-    tdwr2 = rotate2(tdwr2, 'inst', inplace=True)
+    tdwr2 = rotate2(tdwr2, 'inst')
 
     td_awac = tr.dat_awac.copy(deep=True)
     td_awac = rotate2(td_awac, 'inst')  # AWAC is in earth coords
     td_sig = load('BenchFile01_rotate_inst2earth.nc')
-    td_sig = rotate2(td_sig, 'inst', inplace=True)
+    td_sig = rotate2(td_sig, 'inst')
     td_sigi = load('Sig1000_IMU_rotate_inst2earth.nc')
-    td_sig_i = rotate2(td_sigi, 'inst', inplace=True)
+    td_sig_i = rotate2(td_sigi, 'inst')
 
     cd_rdi = load('RDI_test01_rotate_beam2inst.nc')
     cd_awac = load('AWAC_test01_earth2inst.nc')

--- a/dolfyn/tests/test_rotate_adv.py
+++ b/dolfyn/tests/test_rotate_adv.py
@@ -52,11 +52,11 @@ def test_inst2head_rotmat():
 
 def test_rotate_inst2earth(make_data=False):
     td = tr.dat.copy(deep=True)
-    td = rotate2(td, 'earth', inplace=True)
+    td = rotate2(td, 'earth')
     tdm = tr.dat_imu.copy(deep=True)
-    tdm = rotate2(tdm, 'earth', inplace=True)
+    tdm = rotate2(tdm, 'earth')
     tdo = tr.dat.copy(deep=True)
-    tdo = rotate2(tdo.drop_vars('orientmat'), 'earth', inplace=True)
+    tdo = rotate2(tdo.drop_vars('orientmat'), 'earth')
 
     if make_data:
         save(td, 'vector_data01_rotate_inst2earth.nc')
@@ -73,9 +73,9 @@ def test_rotate_inst2earth(make_data=False):
 
 def test_rotate_earth2inst():
     td = load('vector_data01_rotate_inst2earth.nc')
-    td = rotate2(td, 'inst', inplace=True)
+    td = rotate2(td, 'inst')
     tdm = load('vector_data_imu01_rotate_inst2earth.nc')
-    tdm = rotate2(tdm, 'inst', inplace=True)
+    tdm = rotate2(tdm, 'inst')
 
     cd = tr.dat.copy(deep=True)
     cdm = tr.dat_imu.copy(deep=True)
@@ -90,9 +90,9 @@ def test_rotate_earth2inst():
 
 def test_rotate_inst2beam(make_data=False):
     td = tr.dat.copy(deep=True)
-    td = rotate2(td, 'beam', inplace=True)
+    td = rotate2(td, 'beam')
     tdm = tr.dat_imu.copy(deep=True)
-    tdm = rotate2(tdm, 'beam', inplace=True)
+    tdm = rotate2(tdm, 'beam')
 
     if make_data:
         save(td, 'vector_data01_rotate_inst2beam.nc')
@@ -108,9 +108,9 @@ def test_rotate_inst2beam(make_data=False):
 
 def test_rotate_beam2inst():
     td = load('vector_data01_rotate_inst2beam.nc')
-    td = rotate2(td, 'inst', inplace=True)
+    td = rotate2(td, 'inst')
     tdm = load('vector_data_imu01_rotate_inst2beam.nc')
-    tdm = rotate2(tdm, 'inst', inplace=True)
+    tdm = rotate2(tdm, 'inst')
 
     cd = tr.dat.copy(deep=True)
     cdm = tr.dat_imu.copy(deep=True)
@@ -122,10 +122,10 @@ def test_rotate_beam2inst():
 def test_rotate_earth2principal(make_data=False):
     td = load('vector_data01_rotate_inst2earth.nc')
     td.attrs['principal_heading'] = calc_principal_heading(td['vel'])
-    td = rotate2(td, 'principal', inplace=True)
+    td = rotate2(td, 'principal')
     tdm = load('vector_data_imu01_rotate_inst2earth.nc')
     tdm.attrs['principal_heading'] = calc_principal_heading(tdm['vel'])
-    tdm = rotate2(tdm, 'principal', inplace=True)
+    tdm = rotate2(tdm, 'principal')
 
     if make_data:
         save(td, 'vector_data01_rotate_earth2principal.nc')
@@ -145,9 +145,9 @@ def test_rotate_earth2principal_set_declination():
     td0 = td.copy(deep=True)
 
     td.attrs['principal_heading'] = calc_principal_heading(td['vel'])
-    td = rotate2(td, 'principal', inplace=True)
+    td = rotate2(td, 'principal')
     td = set_declination(td, declin)
-    td = rotate2(td, 'earth', inplace=True)
+    td = rotate2(td, 'earth')
 
     td0 = set_declination(td0, -1)
     td0 = set_declination(td0, declin)

--- a/dolfyn/tests/test_rotate_adv.py
+++ b/dolfyn/tests/test_rotate_adv.py
@@ -5,7 +5,7 @@ from dolfyn.rotate.api import rotate2, calc_principal_heading, \
 from dolfyn.rotate.base import euler2orient, orient2euler
 import numpy as np
 import unittest
-from xarray.testing import assert_allclose
+from .base import assert_allclose
 import numpy.testing as npt
 
 

--- a/dolfyn/tests/test_time.py
+++ b/dolfyn/tests/test_time.py
@@ -1,4 +1,5 @@
-from dolfyn.tests import test_read_adv as tr
+from . import test_read_adv as trv
+from . import test_read_adp as trp
 from numpy.testing import assert_equal, assert_allclose
 import numpy as np
 import dolfyn.time as time
@@ -6,37 +7,45 @@ from datetime import datetime
 
 
 def test_epoch2date():
-    td = tr.dat_imu.copy(deep=True)
+    td = trv.dat_imu.copy(deep=True)
+    dat_sig = trp.dat_sig_i.copy(deep=True)
 
-    dt = time.epoch2date(td.time)
-    dt1 = time.epoch2date(td.time[0])
-    dt_off = time.epoch2date(td.time, offset_hr=-7)
-    t_str = time.epoch2date(td.time, to_str=True)
+    dt = time.dt642date(td.time)
+    dt1 = time.dt642date(td.time[0])
+    dt_off = time.epoch2date(time.dt642epoch(td.time), offset_hr=-7)
+    t_str = time.epoch2date(time.dt642epoch(td.time), to_str=True)
 
+    
     assert_equal(dt[0], datetime(2012, 6, 12, 12, 0, 2, 687283))
     assert_equal(dt1, [datetime(2012, 6, 12, 12, 0, 2, 687283)])
     assert_equal(dt_off[0], datetime(2012, 6, 12, 5, 0, 2, 687283))
     assert_equal(t_str[0], '2012-06-12 12:00:02.687283')
 
+    # Validated based on data in ad2cp.index file
+    assert_equal(time.dt642date(dat_sig.time[0])[0],
+                 datetime(2017, 7, 24, 17, 0, 0, 63500))
+    # This should always be true
+    assert_equal(time.epoch2date([0])[0], datetime(1970, 1, 1, 0, 0))
+
 
 def test_datetime():
-    td = tr.dat_imu.copy(deep=True)
+    td = trv.dat_imu.copy(deep=True)
 
-    dt = time.epoch2date(td.time)
+    dt = time.dt642date(td.time)
     epoch = np.array(time.date2epoch(dt))
 
-    assert_allclose(td.time.values, epoch, atol=1e-7)
+    assert_allclose(time.dt642epoch(td.time.values), epoch, atol=1e-7)
 
 
 def test_datenum():
-    td = tr.dat_imu.copy(deep=True)
+    td = trv.dat_imu.copy(deep=True)
 
-    dt = time.epoch2date(td.time)
+    dt = time.dt642date(td.time)
     dn = time.date2matlab(dt)
     dt2 = time.matlab2date(dn)
     epoch = np.array(time.date2epoch(dt2))
 
-    assert_allclose(td.time.values, epoch, atol=1e-6)
+    assert_allclose(time.dt642epoch(td.time.values), epoch, atol=1e-6)
     assert_equal(dn[0], 735032.5000311028)
 
 

--- a/dolfyn/time.py
+++ b/dolfyn/time.py
@@ -10,13 +10,14 @@ def _fullyear(year):
 
 
 def epoch2dt64(ep_time, ):
-    out = np.array(ep_time).astype('datetime64[s]')  # assumes t0=1970-01-01 00:00:00
+    # assumes t0=1970-01-01 00:00:00
+    out = np.array(ep_time.astype('int')).astype('datetime64[s]')
     out = out + ((ep_time % 1) * 1e9).astype('timedelta64[ns]')
     return out
 
 
 def dt642epoch(dt64):
-    return dt64.astype('datetime64[ns]').astype('int') / 1e9
+    return dt64.astype('datetime64[ns]').astype('float') / 1e9
 
 
 def date2dt64(dt):

--- a/dolfyn/time.py
+++ b/dolfyn/time.py
@@ -8,14 +8,14 @@ def _fullyear(year):
     return year
 
 
-def epoch2date(ds_time, offset_hr=0, to_str=False):
+def epoch2date(ep_time, offset_hr=0, to_str=False):
     """
     Convert from epoch time (seconds since 1/1/1970 00:00:00) to a list 
     of datetime objects
 
     Parameters
     ----------
-    ds_time : xarray.DataArray
+    ep_time : xarray.DataArray
         Time coordinate data-array or single time element
     offset_hr : int
         Number of hours to offset time by (e.g. UTC -7 hours = PDT)
@@ -34,15 +34,20 @@ def epoch2date(ds_time, offset_hr=0, to_str=False):
     deployment computer, which is unknown to |dlfn|.
 
     """
-    ds_time = ds_time.values
+    try:
+        ep_time = ep_time.values
+    except AttributeError:
+        pass
 
-    if ds_time.size == 1:
-        ds_time = [ds_time.item()]
-
-    time = [datetime.fromtimestamp(t) for t in ds_time]
+    if ep_time.size == 1:
+        ep_time = [ep_time.item()]
 
     if offset_hr != 0:
-        time = [t + timedelta(hours=offset_hr) for t in time]
+        delta = timedelta(hours=offset_hr)
+        time = [datetime.fromtimestamp(t) + delta for t in ep_time]
+    else:
+        time = [datetime.fromtimestamp(t) for t in ep_time]
+
     if to_str:
         time = date2str(time)
 

--- a/dolfyn/time.py
+++ b/dolfyn/time.py
@@ -8,6 +8,24 @@ def _fullyear(year):
     return year
 
 
+def epoch2dt64(ep_time, ):
+    out = np.array(ep_time).astype('datetime64[s]')  # assumes t0=1970-01-01 in ep_time
+    out = out + ((ep_time % 1) * 1e9).astype('timedelta64[ns]')
+    return out
+
+
+def dt642epoch(dt64):
+    return (dt64 - np.datetime64('1970-01-01')) / np.timedelta64(1, 's')
+
+
+def date2dt64(dt):
+    return np.array(dt).astype('datetime64[ns]')
+
+
+def dt642date(dt64):
+    return epoch2date(dt642epoch(dt64))
+
+
 def epoch2date(ep_time, offset_hr=0, to_str=False):
     """
     Convert from epoch time (seconds since 1/1/1970 00:00:00) to a list 

--- a/dolfyn/velocity.py
+++ b/dolfyn/velocity.py
@@ -5,7 +5,7 @@ from .time import dt642epoch, dt642date
 from .rotate.api import rotate2
 
 
-@xr.register_dataset_accessor('velds') # 'vel dataset'
+@xr.register_dataset_accessor('velds')  # 'vel dataset'
 class Velocity():
     """All ADCP and ADV xarray datasets wrap this base class.
 
@@ -24,34 +24,30 @@ class Velocity():
 
     ########
     # Major components of the dolfyn-API
-    
-    def rotate2(self, out_frame='earth', inplace=False):
+
+    def rotate2(self, out_frame='earth'):
         """Rotate the dataset to a new coordinate system.
 
         Parameters
         ----------
         out_frame : string {'beam', 'inst', 'earth', 'principal'}
           The coordinate system to rotate the data into.
-        inplace : bool
-          Operate on the input data dataset (True), or return a copy that
-          has been rotated (False, default).
 
         Returns
         -------
         ds : xarray.Dataset
-          The rotated dataset (this is always returned, including when
-          inplace=True)
+          The rotated dataset
 
         Notes
         -----
         This function rotates all variables in ``ds.attrs['rotate_vars']``.
 
         """
-        return rotate2(self, out_frame, inplace)
-    
+        return rotate2(self, out_frame)
+
     ########
     # Magic methods of the API
-    
+
     def __init__(self, ds, *args, **kwargs):
         self.ds = ds
 
@@ -60,7 +56,7 @@ class Velocity():
 
     def __contains__(self, val):
         return val in self.ds
-    
+
     def __repr__(self, ):
         time_string = '{:.2f} {} (started: {})'
         if ('time' not in self or dt642epoch(self['time'][0]) < 1):
@@ -68,7 +64,8 @@ class Velocity():
         else:
             tm = self['time'][[0, -1]].values
             dt = dt642date(tm[0])[0]
-            delta = (dt642epoch(tm[-1]) - dt642epoch(tm[0])) / (3600 * 24)  # days
+            delta = (dt642epoch(tm[-1]) -
+                     dt642epoch(tm[0])) / (3600 * 24)  # days
             if delta > 1:
                 units = 'days'
             elif delta * 24 > 1:
@@ -114,14 +111,14 @@ class Velocity():
                      'orientmat', 'heading', 'pitch', 'roll',
                      'temp', 'press*', 'amp*', 'corr*',
                      'accel', 'angrt', 'mag',
-                     'echo', 
+                     'echo',
                      ]
         n = 0
         for v in show_vars:
             if n > 12:
                 break
             if v.endswith('*'):
-                v = v[:-1] # Drop the '*'
+                v = v[:-1]  # Drop the '*'
                 for nm in self.variables:
                     if n > 12:
                         break
@@ -145,15 +142,15 @@ class Velocity():
     def attrs(self, ):
         """The attributes in the dataset."""
         return self.ds.attrs
-        
+
     @property
     def coords(self, ):
         """The coordinates in the dataset."""
         return self.ds.coords
 
-
     ######
     # A bunch of DOLfYN specific properties
+
     @property
     def u(self,):
         """The first velocity component.

--- a/dolfyn/velocity.py
+++ b/dolfyn/velocity.py
@@ -1,7 +1,7 @@
 import numpy as np
 import xarray as xr
 from .binned import TimeBinner
-from .time import epoch2date
+from .time import dt642epoch, dt642date
 from .rotate.api import rotate2
 
 
@@ -63,12 +63,12 @@ class Velocity():
     
     def __repr__(self, ):
         time_string = '{:.2f} {} (started: {})'
-        if ('time' not in self or self['time'][0] < 1):
+        if ('time' not in self or dt642epoch(self['time'][0]) < 1):
             time_string = '-->No Time Information!<--'
         else:
-            tm = [self['time'][0], self['time'][-1]]
-            dt = epoch2date(tm[0])[0]
-            delta = float((tm[-1] - tm[0])) / (3600 * 24)  # days
+            tm = self['time'][[0, -1]].values
+            dt = dt642date(tm[0])[0]
+            delta = (dt642epoch(tm[-1]) - dt642epoch(tm[0])) / (3600 * 24)  # days
             if delta > 1:
                 units = 'days'
             elif delta * 24 > 1:
@@ -85,7 +85,7 @@ class Velocity():
                                                  dt.strftime('%b %d, %Y %H:%M'))
             except AttributeError:
                 time_string = '-->Error in time info<--'
-    
+
         p = self.ds.attrs
         t_shape = self['time'].shape
         if len(t_shape) > 1:
@@ -100,7 +100,7 @@ class Velocity():
                    "  . %s-frame\n"
                    "  . %s\n" %
                    (p.get('inst_type'),
-                    self.ds.attrs['inst_make'], self.ds.attrs['inst_model'], 
+                    self.ds.attrs['inst_make'], self.ds.attrs['inst_model'],
                     time_string,
                     p.get('coord_sys'),
                     shape_string))

--- a/environment.yml
+++ b/environment.yml
@@ -5,9 +5,9 @@ dependencies:
   - pip
   - python>=3.6
   - pip:
-    - numpy>=1.20
-    - scipy>=1.7.0
-    - six>=1.16.0
-    - xarray>=0.19.0
-    - netcdf4>=1.5.7
-
+      - numpy>=1.20
+      - scipy>=1.7.0
+      - six>=1.16.0
+      - xarray>=0.19.0
+      - netcdf4>=1.5.7
+      - pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ scipy>=1.7.0
 six>=1.16.0
 xarray>=0.18.2
 netcdf4>=1.5.7
+pytest


### PR DESCRIPTION
@jmcvey3- I'm definitely interested in you reviewing this. I think this is a major improvement because now we're using real time objects!

Note that one of the big stumbling blocks I think you ran into was fixed in a25008e. Take a look at the details of [`datetime.fromtimestamp`](https://docs.python.org/3/library/datetime.html#datetime.datetime.fromtimestamp), [`datetime.utcfromtimestamp`](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcfromtimestamp), and [`datetime.timestamp`](https://docs.python.org/3/library/datetime.html#datetime.datetime.timestamp). The fine print there is important! What a mess!

Hurrah!