### PR TITLE
Read error cleanup

### DIFF
--- a/dolfyn/io/base.py
+++ b/dolfyn/io/base.py
@@ -6,6 +6,36 @@ import os
 import warnings
 
 
+def _get_filetype(fname):
+    """Detects whether the file is a Nortek, Signature (Nortek), or RDI
+    file by reading the first few bytes of the file.
+
+    Returns
+    =======
+       None - Doesn't match any known pattern
+       'signature' - for Nortek signature files
+       'nortek' - for Nortek (Vec, AWAC) files
+       'RDI' - for RDI files
+       '<GIT-LFS pointer> - if the file looks like a GIT-LFS pointer.
+    """
+
+    with open(fname, 'rb') as rdr:
+        bytes = rdr.read(40)
+    code = bytes[:2].hex()
+    #print("{} - {}".format(fname.rsplit('/')[-1], bytes))
+    if code in ['7f79', '7f7f']:
+        return 'RDI'
+    elif code in ['a50a']:
+        return 'signature'
+    elif code in ['a505']:
+        # AWAC 
+        return 'nortek'
+    elif bytes == b'version https://git-lfs.github.com/spec/':
+        return '<GIT-LFS pointer>'
+    else:
+        return None
+
+
 def _find_userdata(filename, userdata=True):
     # This function finds the file to read
     if userdata:

--- a/dolfyn/io/base.py
+++ b/dolfyn/io/base.py
@@ -6,6 +6,10 @@ import os
 import warnings
 
 
+def _abspath(fname):
+    return os.path.abspath(os.path.expanduser(fname))
+
+
 def _get_filetype(fname):
     """Detects whether the file is a Nortek, Signature (Nortek), or RDI
     file by reading the first few bytes of the file.

--- a/dolfyn/io/nortek.py
+++ b/dolfyn/io/nortek.py
@@ -3,7 +3,7 @@ import xarray as xr
 from struct import unpack
 import warnings
 from . import nortek_defs
-from .base import _find_userdata, _create_dataset, _handle_nan
+from .base import _find_userdata, _create_dataset, _handle_nan, _abspath
 from .. import time
 from datetime import datetime
 from ..tools import misc as tbx
@@ -139,7 +139,7 @@ class _NortekReader():
                  do_checksum=True, bufsize=100000, nens=None):
         self.fname = fname
         self._bufsize = bufsize
-        self.f = open(fname, 'rb', 1000)
+        self.f = open(_abspath(fname), 'rb', 1000)
         self.do_checksum = do_checksum
         self.filesize  # initialize the filesize.
         self.debug = debug
@@ -202,7 +202,7 @@ class _NortekReader():
         # Run the appropriate initialization routine (e.g. init_ADV).
         getattr(self, 'init_' + self._inst)()
         self.f.close()  # This has a small buffer, so close it.
-        self.f = open(fname, 'rb', bufsize)  # This has a large buffer...
+        self.f = open(_abspath(fname), 'rb', bufsize)  # This has a large buffer...
         self.close = self.f.close
         if self._npings is not None:
             self.n_samp_guess = self._npings + 1

--- a/dolfyn/io/nortek2.py
+++ b/dolfyn/io/nortek2.py
@@ -4,7 +4,7 @@ from struct import unpack, calcsize
 import warnings
 from . import nortek2_defs as defs
 from . import nortek2_lib as lib
-from .base import _find_userdata, _create_dataset
+from .base import _find_userdata, _create_dataset, _abspath
 from ..rotate.vector import _euler2orient
 from ..rotate.base import _set_coords
 from ..rotate.api import set_declination
@@ -124,7 +124,7 @@ class _Ad2cpReader():
             self.f.close()
         except AttributeError:
             pass
-        self.f = open(self.fname, 'rb', bufsize)
+        self.f = open(_abspath(self.fname), 'rb', bufsize)
 
     def _read_filehead_config_string(self, ):
         hdr = self._read_hdr()

--- a/dolfyn/io/nortek2_lib.py
+++ b/dolfyn/io/nortek2_lib.py
@@ -3,6 +3,7 @@ import os.path as path
 import numpy as np
 import warnings
 from .. import time
+from .base import _abspath
 
 def _reduce_by_average(data, ky0, ky1):
     # Average two arrays together, if they both exist.
@@ -92,8 +93,8 @@ def _calc_time(year, month, day, hour, minute, second, usec, zero_is_bad=True):
 
 def _create_index_slow(infile, outfile, N_ens):
     print("Indexing {}...".format(infile), end='')
-    fin = open(infile, 'rb')
-    fout = open(outfile, 'wb')
+    fin = open(_abspath(infile), 'rb')
+    fout = open(_abspath(outfile), 'wb')
     fout.write(b'Index Ver:')
     fout.write(struct.pack('<H', _index_version))
     ens = 0
@@ -143,7 +144,7 @@ def _get_index(infile, reload=False):
     index_file = infile + '.index'
     if not path.isfile(index_file) or reload:
         _create_index_slow(infile, index_file, 2 ** 32)
-    f = open(index_file, 'rb')
+    f = open(_abspath(index_file), 'rb')
     file_head = f.read(12)
     if file_head[:10] == b'Index Ver:':
         index_ver = struct.unpack('<H', file_head[10:])[0]
@@ -196,8 +197,8 @@ def crop_ensembles(infile, outfile, range):
         n_ID = len(np.unique(idx['ID']))
         idx_act = np.arange(0, len(idx)//n_ID, 1)
         idx['ens'] = np.sort(np.tile(idx_act, n_ID))
-    with open(infile, 'rb') as fin:
-        with open(outfile, 'wb') as fout:
+    with open(_abspath(infile), 'rb') as fin:
+        with open(_abspath(outfile), 'wb') as fout:
             fout.write(fin.read(idx['pos'][0]))
             i0 = np.nonzero(idx['ens'] == range[0])[0][0]
             ie = np.nonzero(idx['ens'] == range[1])[0][0]

--- a/dolfyn/io/rdi.py
+++ b/dolfyn/io/rdi.py
@@ -4,7 +4,7 @@ from .. import time as tmlib
 import warnings
 from os.path import getsize
 from ._read_bin import bin_reader
-from .base import _find_userdata, _create_dataset
+from .base import _find_userdata, _create_dataset, _abspath
 from ..rotate.rdi import _calc_beam_orientmat, _calc_orientmat
 from ..rotate.base import _set_coords
 from ..rotate.api import set_declination
@@ -284,7 +284,7 @@ class _RdiReader():
     extrabytes = 0
 
     def __init__(self, fname, navg=1, debug_level=0):
-        self.fname = fname
+        self.fname = _abspath(fname)
         print('\nReading file {} ...'.format(fname))
         self._debug_level = debug_level
         self.cfg = {}
@@ -292,13 +292,13 @@ class _RdiReader():
         self.cfg['sourceprog'] = 'instrument'
         self.cfg['prog_ver'] = 0
         self.hdr = {}
-        self.f = bin_reader(fname)
+        self.f = bin_reader(self.fname)
         self.read_hdr()
         self.read_cfg()
         self.f.seek(self._pos, 0)
         self.n_avg = navg
         self.ensemble = _ensemble(self.n_avg, self.cfg['n_cells'])
-        self._filesize = getsize(fname)
+        self._filesize = getsize(self.fname)
         self._npings = int(self._filesize / (self.hdr['nbyte'] + 2 +
                                              self.extrabytes))
         self.vars_read = _variable_setlist(['time'])


### PR DESCRIPTION
@jmcvey3 -

I decided to tackle #72 after all.

All of the test files work for the definitions I've specified in the `dolfyn.io.base._get_filetype`. I think this is a much more robust method of detecting file-type, and if something falls outside these definitions I think the error messages are pretty clear.

Sorry to duplicate/overule your effort in #74 . Let me know what you think?