### PR TITLE
Allow Velocity or Dataset inputs for API functions

### DIFF
--- a/dolfyn/io/api.py
+++ b/dolfyn/io/api.py
@@ -8,6 +8,8 @@ from .rdi import read_rdi
 from .base import _create_dataset, _get_filetype
 from ..rotate.base import _set_coords
 from ..time import date2matlab, matlab2date, date2dt64, dt642date
+import dolfyn.tools.misc as misc
+vd_decorator = misc._velocity_dataset_decorator
 
 
 # time variables stored as data variables (as opposed to coordinates)
@@ -79,7 +81,7 @@ def read_example(name, **kwargs):
         'example_data/' + name)
     return read(filename, **kwargs)
 
-
+@vd_decorator
 def save(dataset, filename,
          format='NETCDF4', engine='netcdf4',
          **kwargs):
@@ -176,6 +178,7 @@ def load(filename):
     return ds
 
 
+@vd_decorator
 def save_mat(dataset, filename, datenum=True):
     """Save xarray dataset as a MATLAB (.mat) file
 

--- a/dolfyn/rotate/api.py
+++ b/dolfyn/rotate/api.py
@@ -3,9 +3,11 @@ from . import awac as r_awac
 from . import signature as r_sig
 from . import rdi as r_rdi
 from .base import _make_model
+import dolfyn.tools.misc as misc
 import numpy as np
 import xarray as xr
 import warnings
+vd_decorator = misc._velocity_dataset_decorator
 
 
 # The 'rotation chain'
@@ -22,6 +24,7 @@ rot_module_dict = {
     'rdi': r_rdi}
 
 
+@vd_decorator
 def rotate2(ds, out_frame='earth', inplace=True):
     """Rotate a dataset to a new coordinate system.
 
@@ -119,6 +122,7 @@ def rotate2(ds, out_frame='earth', inplace=True):
         return ds
 
 
+@vd_decorator
 def calc_principal_heading(vel, tidal_mode=True):
     """Compute the principal angle of the horizontal velocity.
 
@@ -168,6 +172,7 @@ def calc_principal_heading(vel, tidal_mode=True):
     return np.round((90 - np.rad2deg(pang)), decimals=4)
 
 
+@vd_decorator
 def set_declination(ds, declin, inplace=True):
     """Set the magnetic declination
 
@@ -214,7 +219,6 @@ def set_declination(ds, declin, inplace=True):
       'True' earth coordinate system)
 
     """
-    if ds
     # Create and return deep copy if not writing "in place"
     if not inplace:
         ds = ds.copy(deep=True)
@@ -254,7 +258,7 @@ def set_declination(ds, declin, inplace=True):
     if not inplace:
         return ds
 
-
+@vd_decorator
 def set_inst2head_rotmat(ds, rotmat, inplace=True):
     """
     Set the instrument to head rotation matrix for the Nortek ADV if it

--- a/dolfyn/rotate/api.py
+++ b/dolfyn/rotate/api.py
@@ -214,6 +214,7 @@ def set_declination(ds, declin, inplace=True):
       'True' earth coordinate system)
 
     """
+    if ds
     # Create and return deep copy if not writing "in place"
     if not inplace:
         ds = ds.copy(deep=True)

--- a/dolfyn/velocity.py
+++ b/dolfyn/velocity.py
@@ -2,8 +2,6 @@ import numpy as np
 import xarray as xr
 from .binned import TimeBinner
 from .time import dt642epoch, dt642date
-from .rotate.api import rotate2, set_declination, set_inst2head_rotmat
-from .io.api import save
 
 
 @xr.register_dataset_accessor('velds')  # 'vel dataset'
@@ -59,6 +57,9 @@ class Velocity():
           the principal direction.
 
         """
+        # This import statement needs to be here to avoid a
+        # circular-dependency
+        from .rotate.api import rotate2
         return rotate2(self.ds, out_frame, inplace)
 
     def set_declination(self, declin, inplace=True):
@@ -107,6 +108,9 @@ class Velocity():
         'True' earth coordinate system)
 
         """
+        # This import statement needs to be here to avoid a
+        # circular-dependency
+        from .rotate.api import set_declination
         return set_declination(self.ds, declin, inplace)
 
     def set_inst2head_rotmat(self, rotmat, inplace=True):
@@ -137,6 +141,9 @@ class Velocity():
         coordinate system).
 
         """
+        # This import statement needs to be here to avoid a
+        # circular-dependency
+        from .rotate.api import set_inst2head_rotmat
         return set_inst2head_rotmat(self.ds, rotmat, inplace)
 
     def save(self, filename, **kwargs):
@@ -154,6 +161,9 @@ class Velocity():
         additional details.
 
         """
+        # This import statement needs to be here to avoid a
+        # circular-dependency
+        from .io.api import save
         save(self.ds, filename, **kwargs)
     
     ########

--- a/todo-branch.md
+++ b/todo-branch.md
@@ -1,0 +1,20 @@
+# NOTE
+
+The idea here is that API functions (such as `rotate2`) can handle (take as input and return the matching dtype) either `xarray.Dataset` or `velocity.Velocity` objects. i.e.:
+
+    dsi = dolfyn.read('some raw file in inst coords')
+    vdsi = dsi.velds
+    vdse = dolfyn.rotate2(vdsi, 'earth', inplace=False) # an velocity.Velocity is returned (matches input vdsi)
+    dse = dolfyn.rotate2(dsi, 'earth', inplace=False) # an xarray.Dataset is returned (matches input dsi)
+
+This seems like a really nice feature, however it is problematic when doing something like this:
+
+    _dse = dsi.velds.rotate2('earth', inplace=False)
+    
+In this case it is unclear whether `_dse` should be a `Velocity` object or a `Dataset` (currently it's a `Dataset`). The obvious solution to this would be to remove the option for `inplace=False` from the `velocity.Velocity` methods and always do `inplace=True`. However, I think `inplace=False` is sometimes nice. On the other hand, this can easily be accomplished with the *function*.
+
+# TODO
+
+If this goes forward, we still need to:
+- document the behavior in the api-docs
+- add some tests.


### PR DESCRIPTION
The idea here is that API functions (such as `rotate2`) can handle (take as input and return the matching dtype) either `xarray.Dataset` or `velocity.Velocity` objects. i.e.:

    dsi = dolfyn.read('some raw file in inst coords')
    vdsi = dsi.velds
    vdse = dolfyn.rotate2(vdsi, 'earth', inplace=False) # an velocity.Velocity is returned (matches input vdsi)
    dse = dolfyn.rotate2(dsi, 'earth', inplace=False) # an xarray.Dataset is returned (matches input dsi)

This seems like a really nice feature, however it is problematic when doing something like this:

    _dse = dsi.velds.rotate2('earth', inplace=False)
    
In this case it is unclear whether `_dse` should be a `Velocity` object or a `Dataset` (currently it's a `Dataset`). The obvious solution to this would be to remove the option for `inplace=False` from the `velocity.Velocity` methods and always do `inplace=True`. However, I think `inplace=False` is sometimes nice. On the other hand, this can easily be accomplished with the *function*.
